### PR TITLE
[Backtracking] 백준 2961 도영이가 만든 맛있는 음식 / 10819 차이를 최대로

### DIFF
--- a/backtracking/bj10819.kt
+++ b/backtracking/bj10819.kt
@@ -1,0 +1,42 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import kotlin.math.abs
+
+/*
+* 10819 차이를 최대로
+*/
+
+fun main() = with(BufferedReader(InputStreamReader(System.`in`))) {
+    val n = readLine().toInt()
+    val nums = IntArray(n) { 0 }
+    val visited = BooleanArray(n)
+    val pick = ArrayList<Int>(n + 1)
+    val result = ArrayList<Int>()
+    readLine().split(" ").map { it.toInt() }.forEachIndexed { index, i ->
+        nums[index] = i
+    }
+
+    fun backtracking(depth: Int) {
+
+        if (depth == n) {
+            var temp = 0
+            repeat(n - 1) {
+                temp += abs(pick[it] - pick[it + 1])
+            }
+            result.add(temp)
+        }
+
+        for (i in 0..n - 1) {
+            if (!visited[i]) {
+                visited[i] = true
+                pick.add(nums[i])
+                backtracking(depth + 1)
+                pick.removeLast()
+                visited[i] = false
+            }
+        }
+
+    }
+    backtracking(0)
+    print(result.max())
+}

--- a/backtracking/bj2961.kt
+++ b/backtracking/bj2961.kt
@@ -1,0 +1,42 @@
+/*
+* 도영이가 만든 맛있는 음식
+*/
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.lang.StrictMath.min
+import kotlin.math.abs
+
+fun main() = with(BufferedReader(InputStreamReader(System.`in`))) {
+    val n = readLine().toInt()
+    var result = Long.MAX_VALUE
+    val ingredients = ArrayList<Pair<Int, Int>>(n)
+    val visited = BooleanArray(n)
+
+    repeat(n) {
+        val (s, b) = readLine().split(" ").map { it.toInt() }
+        ingredients.add(Pair(s, b))
+    }
+
+    fun backtrack(depth: Int) {
+        for (i in depth..n - 1) {
+            if (!visited[i]) {
+                visited[i] = true
+
+                var s: Long = 1
+                var b: Long = 0
+                visited.forEachIndexed { index, boolean ->
+                    if (boolean) {
+                        s *= ingredients[index].first
+                        b += ingredients[index].second
+                    }
+                }
+                result = min(result, abs(s - b))
+
+                backtrack(depth + 1)
+                visited[i] = false
+            }
+        }
+    }
+    backtrack(0)
+    print(result)
+}

--- a/backtracking/bj2961_ inefficiency.kt
+++ b/backtracking/bj2961_ inefficiency.kt
@@ -1,0 +1,43 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.lang.StrictMath.min
+import kotlin.math.abs
+
+/*
+* 2961 도영이가 만든 맛있는 음식 비효율코드
+*/
+
+fun main() = with(BufferedReader(InputStreamReader(System.`in`))) {
+    val n = readLine().toInt()
+    var result = Long.MAX_VALUE
+    val ingredients = ArrayList<Pair<Int, Int>>(n)
+    val visited = BooleanArray(n)
+
+    repeat(n) {
+        val (s, b) = readLine().split(" ").map { it.toInt() }
+        ingredients.add(Pair(s, b))
+    }
+
+    fun backtrack(depth: Int) {
+        if (depth != 0) {
+            var s: Long = 1
+            var b: Long = 0
+            visited.forEachIndexed { index, boolean ->
+                if (boolean) {
+                    s *= ingredients[index].first
+                    b += ingredients[index].second
+                }
+            }
+            result = min(result, abs(s - b))
+        }
+        repeat(n) {
+            if (!visited[it]) {
+                visited[it] = true
+                backtrack(depth + 1)
+                visited[it] = false
+            }
+        }
+    }
+    backtrack(0)
+    print(result)
+}


### PR DESCRIPTION
<!-- 🔥 Assignee, Label, Reviewer 설정!!!🔥 -->

## 📒 문제번호 :
- 2961 도영이가 만든 맛있는 음식
![image](https://user-images.githubusercontent.com/70648111/227706501-d5436bdb-fc4e-4b96-8030-c78174da03d2.png)

- 10819 차이를 최대로
![image](https://user-images.githubusercontent.com/70648111/227706509-79900dd5-26ef-47c8-84a4-1388a65e6fd1.png)

## ☑️ PR Point

<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->

- 기본적으로 dfs를 기반으로 하여 백트래킹을 구현하였습니다. 
- 2961은 백트래킹을 활용하여 모든 조합을 구하는 문제입니다. 다만, 몇가지를 선택하야 한다는 조건은 없기 때문에 visited를 활용하여 visited가 true인 경우에만 조합을 선택하여 구했습니다.
- 처음에는 이러한 부분을 고려하지 않고 매번 처음부터 for문을 통해 검사해주어서 시간이 최적화한 코드보다 7배가 차이가 났습니다. (비효율버전 코드의 repeat부분을 for(i in depth..n-1)로 바꾸어서 불필요한 for문 제거)
- 10819는 순열을 활용하는 경우였습니다. 따라서 for문 내부에서 무조건 탐색을 시작하는 부분을 처음부터 시작하여 순서까지 고려하여 경우의 수를 계산해주었습니다.
- 이걸 참고해도 좋을것 같습니다 #19 

## ⏱️시간복잡도
O(2^n)