### PR TITLE
[BFS] bj7576 토마토 / bj14502 연구소

### DIFF
--- a/bfs/bj14502.kt
+++ b/bfs/bj14502.kt
@@ -1,0 +1,106 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.lang.Integer.max
+import java.util.LinkedList
+
+/*
+14502 연구소
+
+// row = n = y = r = [][]에서 첫번째 오는 거
+// col = m = x = c = [][]에서 두번째 오는 거
+
+ */
+
+fun main() = with(BufferedReader(InputStreamReader(System.`in`))) {
+    val (n, m) = readLine().split(" ").map { it.toInt() }
+    val lab = Array(n) { IntArray(m) }
+    val visited = Array(n) { BooleanArray(m) }
+    val vi = LinkedList<Pair<Int, Int>>()
+    var count = 0
+    val temp = Array(n) { IntArray(m) } // 벽이 세워지는 경우의 수를 넣어주는 경우
+    val queue = LinkedList<Pair<Int, Int>>()
+    var result = 0
+    repeat(n) {
+        readLine().split(" ").map { it.toInt() }.forEachIndexed { index, i ->
+            lab[it][index] = i
+            if (i == 2) queue.add(Pair(it, index)) // 최초 바이러스의 시작점들을 
+        }
+    }
+
+    fun bfs(virus: LinkedList<Pair<Int, Int>>) {
+        while (virus.isNotEmpty()) {
+            val size = virus.size
+            repeat(size) {// 최초 시작점만큼 퍼뜨리기 위해서 bfs
+                val head = virus.poll()
+                val row = head.first
+                val col = head.second
+                if (row + 1 < n) {
+                    if (temp[row + 1][col] == 0) {
+                        temp[row + 1][col] = 2
+                        virus.offer(Pair(row + 1, col))
+                    }
+                }
+                if (row - 1 >= 0) {
+                    if (temp[row - 1][col] == 0) {
+                        temp[row - 1][col] = 2
+                        virus.offer(Pair(row - 1, col))
+                    }
+
+                }
+                if (col + 1 < m) {
+                    if (temp[row][col + 1] == 0) {
+                        temp[row][col + 1] = 2
+                        virus.offer(Pair(row, col + 1))
+                    }
+
+                }
+                if (col - 1 >= 0) {
+                    if (temp[row][col - 1] == 0) {
+                        temp[row][col - 1] = 2
+                        virus.offer(Pair(row, col - 1))
+                    }
+                }
+            }
+        }
+    }
+
+
+    fun backtrack(depth: Int) {
+        if (depth == 3) {
+            lab.forEachIndexed { col, rows ->
+                rows.forEachIndexed { row, i ->
+                    temp[col][row] = i
+                }
+            } // 원본 연구실의 배치를 가져옴
+            visited.forEachIndexed { col, rows ->
+                rows.forEachIndexed { row, b ->
+                    if (b) temp[col][row] = 1
+                }
+            }// 백트래킹을 통해서 벽을 3개 세운 경우를 복사본 연구실에 적용
+            queue.forEach {
+                vi.add(it) //최초 시작점 넘겨주기 위함
+            }
+            bfs(vi)
+            count = 0
+            temp.forEach {
+                count += it.count { it == 0 } // 0의 갯수를 세서 결과값에 갱신
+            }
+            result = max(result, count)
+            return
+        }
+
+        //조합을 위한 백트래킹
+        for (i in 0 until n) {
+            for (j in 0 until m) {
+                if (lab[i][j] == 0 && !visited[i][j]) {
+                    visited[i][j] = true
+                    backtrack(depth + 1)
+                    visited[i][j] = false
+                }
+            }
+        }
+    }
+    backtrack(0)
+    print(result)
+
+}

--- a/bfs/bj7576.kt
+++ b/bfs/bj7576.kt
@@ -1,0 +1,74 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.util.*
+
+/*
+* 7576 토마토
+*/
+
+fun main() = with(BufferedReader(InputStreamReader(System.`in`))) {
+    val (m, n) = readLine().split(" ").map { it.toInt() }
+    val box = Array(n) { IntArray(m) }
+    var day = 0
+    var unripe = 0
+    val queue = LinkedList<Pair<Int, Int>>()
+
+    repeat(n) {
+        readLine().split(" ").map { it.toInt() }.forEachIndexed { index, c ->
+            box[it][index] = c
+            when (c) {
+                1 -> queue.add(Pair(it, index)) // 익은 토마토 = 출발점
+                0 -> unripe++ // 안익은 토마토 
+            }
+        }
+    }
+
+    fun bfs() {
+        while (queue.isNotEmpty()) {
+            day++ // 한번 퍼뜨리는 시점을 여기서 구해줌
+            val size = queue.size
+            repeat(size) { // 처음 익은 토마토의 개수 만큼 bfs
+                val head = queue.poll()
+                val dx = head.first
+                val dy = head.second
+                if (dx + 1 < n) {
+                    if (box[dx + 1][dy] == 0) {
+                        box[dx + 1][dy] = 1
+                        unripe--
+                        queue.offer(Pair(dx + 1, dy))
+                    }
+                }
+                if (dx - 1 >= 0) {
+                    if (box[dx - 1][dy] == 0) {
+                        box[dx - 1][dy] = 1
+                        unripe--
+                        queue.offer(Pair(dx - 1, dy))
+                    }
+                }
+                if (dy + 1 < m) {
+                    if (box[dx][dy + 1] == 0) {
+                        box[dx][dy + 1] = 1
+                        unripe--
+                        queue.offer(Pair(dx, dy + 1))
+                    }
+
+                }
+                if (dy - 1 >= 0) {
+                    if (box[dx][dy - 1] == 0) {
+                        box[dx][dy - 1] = 1
+                        unripe--
+                        queue.offer(Pair(dx, dy - 1))
+                    }
+                }
+            }
+        }
+    }
+
+    if (unripe == 0) {
+        print(0)
+    } else {
+        bfs()
+        if(unripe > 0) print(-1)
+        else print(day-1)
+    }
+}


### PR DESCRIPTION
<!-- 🔥 Assignee, Label, Reviewer 설정!!!🔥 -->

## 📒 문제번호 :
- bj 7576 토마토
![image](https://user-images.githubusercontent.com/70648111/229281071-e1bd4fc5-d8dc-43f0-bfbe-032defc8fabf.png)

- bj 14502 연구소
![image](https://user-images.githubusercontent.com/70648111/229281082-636f1be3-59f2-4dbd-80c0-074421084d32.png)

## ☑️ PR Point

<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->

- bfs가 익숙하지 않다보니 실수가 몇가지 발생했습니다. 대표적으로 x y , row col등 입력값에 따라서 2차원 배열을 접근할때 네이밍에 대해서 조금 신경써주어야 합니다. 
- 두 문제 공통적으로 특정 위치에서 인접위치에 대해서 동시다발적으로 영향을 미친다는 것입니다. 그렇게 해주기 위해서 입력값에서 미리 시작점을 선입선출을 위한 queue에 받아두고 그 queue의 size만큼 bfs를 해주어서 그 기준으로 동시다발적으로 퍼뜨리는 시점을 구할 수 있었습니다. 
- 연구소 문제의 경우 벽을 세우는 경우에 대해서 백트래킹을 활용 조합을 생성하여서 그 조합대로 BFS를 통해 바이러스를 퍼뜨렸습니다. 

