### PR TITLE
[백트래킹] 치킨배달 / 불량사용자

### DIFF
--- a/backtracking/bj15686.kt
+++ b/backtracking/bj15686.kt
@@ -1,0 +1,60 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+/*
+* 15686 치킨배달
+*/
+
+fun main() = with(BufferedReader(InputStreamReader(System.`in`))) {
+
+    val (n, m) = readLine().split(" ").map { it.toInt() }
+    var count = 0
+    val result = mutableListOf<Int>()
+    val chicken = mutableListOf<Pair<Int, Int>>()
+    val house = mutableListOf<Pair<Int, Int>>()
+    val visited = Array(n) { BooleanArray(n) }
+
+    repeat(n) { col ->
+        readLine().split(" ").map { it.toInt() }.forEachIndexed { row, i ->
+            if (i == 2) {
+                count++
+                chicken.add(Pair(col, row))
+            }
+            if (i == 1) {
+                house.add(Pair(col, row))
+            }
+        }
+    }
+
+    fun backtrack(chick: Int, start: Int) {
+        if (chick == m) {
+            // 최대값까지 폐쇄되었으면 브루트포스로 거리계산
+            var total = 0
+            house.forEach {
+                val col = it.first
+                val row = it.second
+                var temp = Int.MAX_VALUE
+                chicken.forEach { chi ->
+                    if (!visited[chi.first][chi.second]) temp =
+                        (kotlin.math.abs(col - chi.first) + kotlin.math.abs(row - chi.second)).coerceAtMost(temp)
+                }
+                total += temp
+            }
+            result.add(total)
+            return
+        }
+
+        for (i in start until chicken.size) { //start를 통해서 중복 조합의 경우를 제거해준다.
+            val col = chicken[i].first
+            val row = chicken[i].second
+            if (!visited[col][row]) {
+                visited[col][row] = true //ture하면 폐쇄처리
+                backtrack(chick - 1, i)
+                visited[col][row] = false
+            }
+        }
+    }
+    backtrack(count, 0)
+    println(result.min())
+
+}

--- a/backtracking/programmers_64064.kt
+++ b/backtracking/programmers_64064.kt
@@ -1,0 +1,43 @@
+/*
+* 프로그래머스64064 불량 사용자
+*/
+
+class Solution {
+    fun solution(user_id: Array<String>, banned_id: Array<String>): Int {
+        var answer = 0
+        val result = mutableSetOf<MutableList<String>>()
+        val visited = BooleanArray(user_id.size)
+        val temp = mutableListOf<String>()
+                
+        fun backtrack(start:Int, depth : Int){
+            if(depth == banned_id.size){
+                result.add(temp.sorted().toMutableList())
+                return
+            }
+            
+            for(i in 0 until user_id.size){
+                val con = banned_id[depth]
+                    if(!visited[i]){
+                        val user = user_id[i]
+                        if(con.length == user.length){
+                            var flag = true
+                            con.forEachIndexed{ index, ch ->
+                            if(ch != user[index]) 
+                                if(ch != '*') flag = false
+                            }
+                            if(flag){
+                                visited[i]= true
+                                temp.add(user)
+                                backtrack(i, depth+1)
+                                temp.remove(user)
+                                visited[i]=false
+                            }
+                        }
+                    }
+            }
+        }
+        backtrack(0,0)
+        answer = result.size
+        return answer
+    }
+}


### PR DESCRIPTION
<!-- 🔥 Assignee, Label, Reviewer 설정!!!🔥 -->

## 📒 문제번호 : 
- 백준15686 치킨배달
![image](https://github.com/AlgoHARA/Junwoo/assets/70648111/7fc79063-5c05-4ffc-a7a2-e190075ab349)

- 프로그래머스 64064 불량 사용자
![image](https://github.com/AlgoHARA/Junwoo/assets/70648111/525e7ddd-b921-4a85-b118-c9d16f04a7cf)

## ☑️ PR Point

<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->

- 둘다 공통적으로 dfs를 기반으로 한 백트래킹 문제를 통해서 경우의 수를 파악하는 문제였습니다. 
- 치킨배달의 경우 중복 조합의 경우의 수가 의미가 없으므로 start라는 매개변수를 하나 넘겨주어서 중복되는 조합의 경우에는 탐색하지 않도록 하여 시간초과를 해결하였습니다
- 불량 사용자의 경우 단순하게 중복조합을 제거하게 되면 불량사용자를 판단하는 경우의 수를 모두 탐색하지 못하는 문제가 있어서 set을 통해서 경우의 수를 모두 제거하지는 않되 순서 상관없이 불량사용자의 중복이 발생이 하지 않도록 해결 해주었습니다.
